### PR TITLE
Inject model to fields and blocks

### DIFF
--- a/src/Types.php
+++ b/src/Types.php
@@ -54,9 +54,9 @@ class Types
         return A::get($this->config, $key, $default);
     }
 
-    public function formField(string $type): Form\Field|Form\FieldClass
+    public function formField(string $type, array $attrs = []): Form\Field|Form\FieldClass
     {
-        return $this->formFields[$type] ??= Form\Field::factory($type);
+        return $this->formFields[$type] ??= Form\Field::factory($type, $attrs);
     }
 
     public function fieldset(string $path, array $field): ?Fieldset
@@ -199,7 +199,11 @@ class Types
     public function withBlocks(): void
     {
         foreach ($this->app->blueprints('blocks') as $block) {
-            $this->addBlock($block);
+            $this->addBlock(Page::factory([
+                'template' => 'test',
+                'model'    => 'test',
+                'slug'     => 'test',
+            ]), $block);
         }
     }
 
@@ -304,7 +308,7 @@ class Types
         }
     }
 
-    public function addBlock(string $block): void
+    public function addBlock(ModelWithContent $model, string $block): void
     {
         if (str_starts_with($block, '_')) {
             return;
@@ -321,8 +325,10 @@ class Types
             'tabs.*.fields',
         ]);
 
+        $fields = $this->injectModel($fields, $model);
+
         foreach ($fields as $name => $field) {
-            if (! $this->formField($field['type'])->isSaveable()) {
+            if (! $this->formField($field['type'], $field)->isSaveable()) {
                 continue;
             }
 
@@ -343,7 +349,7 @@ class Types
         $target = new ReflectionClass($model);
 
         $blueprint = $model->blueprint();
-        $fields    = $blueprint->fields();
+        $fields    = $this->injectModel($blueprint->fields(), $model);
         $name      = strtolower($name ?? $blueprint->name());
 
         $this->addBlueprintFields($name, $fields, $target);
@@ -360,7 +366,7 @@ class Types
                 $field = ['type' => $name];
             }
 
-            if (! $this->formField($field['type'])->isSaveable()) {
+            if (! $this->formField($field['type'], $field)->isSaveable()) {
                 continue;
             }
 
@@ -477,5 +483,10 @@ class Types
     public function getMethodReflectionKey(string $name, ReflectionClass $target): string
     {
         return strtolower($target->getName() . '::' . $name);
+    }
+
+    private function injectModel(array $fields, ModelWithContent $model): array
+    {
+        return A::map($fields, fn (array $field) => [...$field, 'model' => $model]);
     }
 }


### PR DESCRIPTION
Hey, 

thanks again for this wonderful extension. As discussed on Discord I gave the `develop` branch a try and ran into two issues (of the same kind). This PR seems to fix it, but please have a thorough review. 

When running the create command, I got the following error message: `Field requires a model`. [The exception was thrown here.](https://github.com/getkirby/kirby/blob/main/src/Form/Field.php#L63)

```
Field.php:63, Kirby\Form\Field->__construct()
Field.php:297, Kirby\Form\Field::factory()
Types.php:59, LukasKleinschmidt\Types\Types->formField()
Types.php:363, LukasKleinschmidt\Types\Types->addBlueprintFields()
Types.php:349, LukasKleinschmidt\Types\Types->addBlueprint()
Types.php:218, LukasKleinschmidt\Types\Types->withBlueprints()
Command.php:101, LukasKleinschmidt\Types\Command->collect()
Command.php:73, LukasKleinschmidt\Types\Command->handle()
Command.php:51, LukasKleinschmidt\Types\Command::run()
index.php:31, Kirby\Filesystem\F::LukasKleinschmidt\Types\{closure:/Users/benedict/dev/project/site/plugins/kirby-types/index.php:30-32}()
CLI.php:583, Kirby\CLI\CLI->run()
CLI.php:103, Kirby\CLI\CLI::command()
kirby:15, include()
kirby:119, {main}()
```

This happened, when the first field was created during creating types for the blueprints. The same applies to blocks. 

[Kirby itself injects the model in the form class for every field.](https://github.com/getkirby/kirby/blob/main/src/Form/Form.php#L72)

This PR injects the model with every field and also creates a model and injects it for blocks.

I have it only tested with Kirby 4.6.1.

Best
Benedict