### PR TITLE
Fix version check for Kirby versions without hyphen

### DIFF
--- a/helpers.php
+++ b/helpers.php
@@ -230,7 +230,10 @@ function file_saveable_k5(string $type): bool
 function field_saveable(string $type): bool
 {
     $version = App::version();
-    $version = strstr($version, '-', true);
+
+    if (str_contains($version, '-')) {
+        $version = strstr($version, '-', true);
+    }
 
     if (version_compare($version, '5.0.0', '>=')) {
         return file_saveable_k5($type);


### PR DESCRIPTION
Hi Lukas,

thanks again for the latest fixes. I run into an issue with a bog-standard Kirby 4 install, because `strstr` returns falls, if there is no hyphen in the version number This PR fixes this. 

After I fixed it, the `develop` branch correctly includes the blueprint fields again in K4 🥳 

Thanks for the work!
Cheers
Benedict