### PR TITLE
Fix null array offset deprecation in alias rendering

### DIFF
--- a/src/Types.php
+++ b/src/Types.php
@@ -100,7 +100,7 @@ class Types
                 continue;
             }
 
-            $aliases[$namespace][$name] = $alias;
+            $aliases[$namespace ?? ''][$name] = $alias;
         }
 
         return snippet('stubs/types-template', [


### PR DESCRIPTION
## Summary
- `Alias::getNamespace()` returns `?string`, and when `null` is used as an array key on [line 103 of `Types.php`](https://github.com/lukaskleinschmidt/kirby-types/blob/main/src/Types.php#L103), it triggers a PHP 8.1+ deprecation warning: *"Using null as an array offset is deprecated, use an empty string instead"*
- Uses `$namespace ?? ''` to fall back to an empty string when the alias has no namespace

## Test plan
- [x] Run `kirby types:create --force` and confirm no deprecation warning is emitted